### PR TITLE
add crun to .PHONY

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MOUNT_POINT := mnt
 
 SUBPROJECTS := $(shell find $(SRC_DIR) -type f -name Makefile)
 
-.PHONY: all img run clean subprojects
+.PHONY: all img run clean subprojects crun
 
 all: img
 


### PR DESCRIPTION
This ensures that no Make implementation expects crun to create files, which it previously expected.